### PR TITLE
added gulp default task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,6 +12,8 @@ var paths = {
   artmobilis_js_ngmodules_src: ['../ArtMobilis-js-ngmodules/modules/**/*']
 };
 
+gulp.task('default', ['minify-artmobilib', 'copy-ngmodules']);
+
 gulp.task('serve', function () {
   electron.start();
   gulp.watch('index.js', electron.restart);


### PR DESCRIPTION
ajout de la tache "default" dans gulp.
ceci permet de lancer "gulp" tout court pour copier les fichiers des autres depots.
